### PR TITLE
Renewing the shares

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,11 +51,11 @@ exports.createShare = function (bls, numOfShares, threshold) {
 /**
  * renew shares and verification vector, while keeping the secret
  * @param {Object} bls - an instance of [bls-lib](https://github.com/wanderer/bls-lib)
- * @param {Number} shares - the array of shares to be renewed (it is not possible to renew only some shares ; all must be)
+ * @param {Number} shares - the array of shares to be renewed (it is not possible to renew only some shares ; all must be). This array will not be modified, and new shares appear in the return object.
  * @param {Number} threshold - the number of share needed to recover the secret
  * @returns {Object} the return value contains the new `verifcationVector`, an array containing the new `shares`, and the `secret` (which has not changed in respect to the original shares)
  */
-exports.renewShare = function (bls, shares, threshold, old_vvec) {
+exports.renewShare = function (bls, shares, threshold, oldVvec) {
   // import secret
   // generate a sk and vvec
   const svec = []
@@ -98,21 +98,21 @@ exports.renewShare = function (bls, shares, threshold, old_vvec) {
     bls.free(sk)
   })
 
-  const new_vvec = old_vvec.map((pk, i) => {
+  const newVvec = oldVvec.map((pk, i) => {
     pk = bls.publicKeyImport(pk)
     bls.publicKeyAdd(pk, vvec[i])
     return pk
   })
 
   const results = {
-    verifcationVector: new_vvec.map(pk => bls.publicKeyExport(pk)),
+    verifcationVector: newVvec.map(pk => bls.publicKeyExport(pk)),
     shares: newShares,
     secret: bls.secretKeyExport(svec[0])
   }
 
   // clean up!
   bls.freeArray(vvec)
-  bls.freeArray(new_vvec)
+  bls.freeArray(newVvec)
   bls.freeArray(svec)
 
   return results

--- a/tests/index.js
+++ b/tests/index.js
@@ -5,7 +5,7 @@ const bls = require('bls-lib')
 bls.onModuleInit(() => {
   tape('tests', (t) => {
     bls.init()
-    
+
     const threshold = 4
     const numOfPlayers = 7
     const setup = vss.createShare(bls, numOfPlayers, threshold)
@@ -13,28 +13,21 @@ bls.onModuleInit(() => {
     setup.shares.forEach(share => {
       const verified = vss.verifyShare(bls, share, setup.verifcationVector)
       t.true(verified, 'should verify share')
-      console.log("Share id", share.id, ":", Buffer.from(share.sk).toString('hex'))
     })
 
     var secret = vss.recoverSecret(bls, setup.shares.slice(0, threshold))
-    console.log("Secret : ", Buffer.from(secret).toString('hex'))
-
     t.deepEqual(secret, setup.secret, 'should recover the secret')
-    
-    
+
     const renewal = vss.renewShare(bls, setup.shares, threshold, setup.verifcationVector)
-    
+
     renewal.shares.forEach(share => {
       const verified = vss.verifyShare(bls, share, renewal.verifcationVector)
       t.true(verified, 'should verify new share')
-      console.log("New share id", share.id, ":", Buffer.from(share.sk).toString('hex'))
     })
-    
-    var secret = vss.recoverSecret(bls, renewal.shares.slice(0, threshold+1))
-    console.log("Secret : ", Buffer.from(secret).toString('hex'))
-    
-    t.deepEqual(setup.secret, secret, 'secret should not change after share renewal')
-    
+
+    secret = vss.recoverSecret(bls, renewal.shares.slice(0, threshold))
+    t.deepEqual(secret, setup.secret, 'secret should not change after share renewal')
+
     t.end()
   })
 })


### PR DESCRIPTION
Shares can now be renewed, using `vss.renewShare`.
It works much in the same way as `createShare`, only the secret is 0 (and not a random secret). Then, the new shares are added to the old ones (through `bls.secretKeyAdd`), thus renewing them all WITHOUT changing the secret (since `old_secret + new_secret = old_secret + 0 = old_secret`).

The verification vector is updated in the same way – after all, it just contains public keys, so the new verification vector is added to the old one.

I also extended the unit test to test share renewal.